### PR TITLE
move amazon button to lazy load

### DIFF
--- a/scripts/pages/checkout.js
+++ b/scripts/pages/checkout.js
@@ -175,13 +175,14 @@ require(["modules/jquery-mozu", "underscore", "hyprlive", "modules/backbone-mozu
             this.model.resetAddressDefaults();
         },
         render: function() {
-            preserveElements(this, ['.v-button', '#amazonButonPaymentSection'], function() {
-                CheckoutStepView.prototype.render.apply(this, arguments);
-            });
-            var status = this.model.stepStatus();
-            if ($("#AmazonPayButton").length > 0 && $("#amazonButonPaymentSection").length > 0)
-                $("#AmazonPayButton").removeAttr("style").appendTo("#amazonButonPaymentSection");
-
+          preserveElements(this, ['.v-button','.p-button', '#AmazonPayButton'], function() {
+            CheckoutStepView.prototype.render.apply(this, arguments);
+            if (AmazonPay.isEnabled && !this.amazonInitialized && this.$('#AmazonPayButton').length > 0) {
+              this.amazonInitialized = true;
+              AmazonPay.addCheckoutButton(window.order.id, false);
+            }
+          });
+          var status = this.model.stepStatus();
             if (visaCheckoutSettings.isEnabled && !this.visaCheckoutInitialized && this.$('.v-button').length > 0) {
                 window.onVisaCheckoutReady = _.bind(this.initVisaCheckout, this);
                 require([pageContext.visaCheckoutJavaScriptSdkUrl]);
@@ -537,7 +538,5 @@ require(["modules/jquery-mozu", "underscore", "hyprlive", "modules/backbone-mozu
 
         $checkoutView.noFlickerFadeIn();
 
-        if (AmazonPay.isEnabled)
-            AmazonPay.addCheckoutButton(window.order.id, false);
     });
 });

--- a/templates/modules/checkout/payment-selector.hypr.live
+++ b/templates/modules/checkout/payment-selector.hypr.live
@@ -96,7 +96,7 @@
                             {% endif %}
                             {% if name == "paywithamazon" %}
                                 <div class="mz-paymenttype" id="amazonButonPaymentSection">
-                                   
+                                  <div id="AmazonPayButton"></div>
                                 </div>    
                             {% endif %}
                         </div>

--- a/templates/pages/checkout.hypr
+++ b/templates/pages/checkout.hypr
@@ -71,7 +71,6 @@
         </div>
 
     </div><!-- left .column -->
-    <div id="AmazonPayButton" style="display:none;"/>
 </form>
 
 </div>


### PR DESCRIPTION
Fixes an error Bluefly is seeing where Amazon doesn't load correctly when the payment selector isn't visible on pageload.
